### PR TITLE
merge Undin's code before I build

### DIFF
--- a/src/main/grammars/RustParser.bnf
+++ b/src/main/grammars/RustParser.bnf
@@ -1044,7 +1044,7 @@ TryMacroArgument ::= <<any_braces AnyExpr>>
 
 // https://doc.rust-lang.org/std/fmt/
 private FormatLikeMacro ::=
-  ("format" | "format_args" | "write" | "writeln" | "print" | "println" | "panic")
+  ("format" | "format_args" | "write" | "writeln" | "print" | "println" | "eprint" | "eprintln" | "panic")
   '!' FormatMacroArgument { pin = 2 }
 
 FormatMacroArgument ::= <<any_braces [ <<comma_separated_list FormatMacroArg>> ] >>

--- a/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
+++ b/src/test/kotlin/org/rust/lang/core/type/RsStdlibExpressionTypeInferenceTest.kt
@@ -212,6 +212,22 @@ class RsStdlibExpressionTypeInferenceTest : RsTypificationTestBase() {
         }
     """)
 
+    fun `test eprint!`() = testExpr("""
+        fn main() {
+            let x = eprint!("Something went wrong");
+            x
+          //^ ()
+        }
+    """)
+
+    fun `test eprintln!`() = testExpr("""
+        fn main() {
+            let x = eprintln!("Something went wrong");
+            x
+          //^ ()
+        }
+    """)
+
     //From the log crate
     fun `test warn!`() = testExpr("""
         fn main() {

--- a/src/test/resources/org/rust/lang/core/parser/fixtures/partial/enum_vis.txt
+++ b/src/test/resources/org/rust/lang/core/parser/fixtures/partial/enum_vis.txt
@@ -10,7 +10,7 @@ FILE
         <empty list>
   PsiWhiteSpace('\n    ')
   PsiElement(pub)('pub')
-  PsiErrorElement:'(', assert, assert_eq, assert_ne, const, debug, debug_assert, debug_assert_eq, debug_assert_ne, enum, error, extern, fn, format, format_args, identifier, impl, info, log, macro_rules, mod, panic, print, println, static, struct, trace, trait, try, type, unsafe, use, vec, warn, write or writeln expected, got 'F'
+  PsiErrorElement:'(', assert, assert_eq, assert_ne, const, debug, debug_assert, debug_assert_eq, debug_assert_ne, enum, eprint, eprintln, error, extern, fn, format, format_args, identifier, impl, info, log, macro_rules, mod, panic, print, println, static, struct, trace, trait, try, type, unsafe, use, vec, warn, write or writeln expected, got 'F'
     <empty list>
   PsiWhiteSpace(' ')
   PsiElement(identifier)('F')


### PR DESCRIPTION
GRAM: parse 'eprint' and 'eprintln' as 'FormatLikeMacro'